### PR TITLE
Support for token send/receive (export/import) between web apps

### DIFF
--- a/src/plugin/config.yml
+++ b/src/plugin/config.yml
@@ -71,6 +71,14 @@ install:
             module: logout
             id: auth2_logout
             type: factory
+        -
+            module: dev/sendToken
+            id: auth2_dev_sendToken
+            type: factory
+        -
+            module: dev/receiveToken
+            id: auth2_dev_receiveToken
+            type: factory
     ko-components:
         -
             name: profile-editor
@@ -161,6 +169,16 @@ install:
             path: ['auth2', 'admin', 'user', {type: param, name: username}]
             widget: auth2_adminUser
             authorization: true
+        -
+            path: ['auth2', 'dev', 'sendToken']
+            widget: auth2_dev_sendToken
+            authorization: true
+        -
+            path: ['auth2', 'dev', 'receiveToken']
+            widget: auth2_dev_receiveToken
+            authorization: false
+            queryParams: 
+                msg: {}
         -
             path: ['auth2', 'signedout']
             widget: auth2_signedout

--- a/src/plugin/modules/components/signinButton.js
+++ b/src/plugin/modules/components/signinButton.js
@@ -83,8 +83,7 @@ define([
                             nextrequest: nextRequest,
                             origin: origin
                         },
-                        provider: provider.id,
-                        stayLoggedIn: false
+                        provider: provider.id
                     });
                 });
         }

--- a/src/plugin/modules/components/signinView.js
+++ b/src/plugin/modules/components/signinView.js
@@ -591,8 +591,7 @@ define([
                             nextrequest: nextRequest,
                             origin: 'signup'
                         },
-                        provider: provider.id,
-                        stayLoggedIn: false
+                        provider: provider.id
                     });
                 }
 

--- a/src/plugin/modules/components/signupView.js
+++ b/src/plugin/modules/components/signupView.js
@@ -638,8 +638,7 @@ define([
                         // entered with a valid token, redirect to the nextrequest,
                         // and if that is empty, the dashboard.
                         state: state,
-                        provider: providerId,
-                        stayLoggedIn: false
+                        provider: providerId
                     });
                 });
         }

--- a/src/plugin/modules/dev/receiveToken.js
+++ b/src/plugin/modules/dev/receiveToken.js
@@ -1,0 +1,364 @@
+define([
+    'knockout-plus',
+    'kb_common/html',
+    'kb_common/bootstrapUtils'
+], function (
+    ko,
+    html,
+    BS
+) {
+    'use strict';
+
+    var t = html.tag,
+        div = t('div'),
+        span = t('span'),
+        p = t('p'),
+        a = t('a'),
+        button = t('button');
+
+    var envs = {
+        ci: {
+            targets: {
+                cialt: {
+                    label: 'Alt CI',
+                    host: 'cialt.kbase.us'
+                },
+            }
+        },
+        cialt: {
+            targets: {
+                ci: {
+                    label: 'CI',
+                    host: 'ci.kbase.us'
+                }
+            }
+        },
+        prod: {
+            targets: {
+                appdev: {
+                    label: 'App Dev',
+                    host: 'appdev.kbase.us'
+                }
+            }
+        }
+    };
+
+    function template() {
+        return div({
+            class: 'container-fluid',
+            style: {
+                width: '100%'
+            }
+        }, [
+            div({ class: 'row' }, [
+                div({ class: 'col-md-6' }, BS.buildPanel({
+                    title: 'Send Token',
+                    body: div({
+
+                    }, [
+                        '<!-- ko if: canSend -->',
+                        a({
+                            href: '#auth2/dev/sendToken'
+                        }, 'Send Token'),
+                        '<!-- /ko -->',
+                        '<!-- ko if: !canSend -->',
+                        p([
+                            'Sorry, you can\'t send tokens from this environment'
+                        ]),
+                        '<!-- /ko -->'
+                    ])
+                })),
+                div({ class: 'col-md-6' }, [
+                    BS.buildPanel({
+                        title: 'Receive Token',
+                        body: div([
+                            // p(['Current token: ', span({
+                            //     dataBind: {
+                            //         text: 'token'
+                            //     }
+                            // })]),
+                            // p(['New token:', span({
+                            //     dataBind: {
+                            //         text: 'newToken.token'
+                            //     }
+                            // })]),
+                            p({
+                                dataBind: {
+                                    html: 'message'
+                                }
+                            }),
+                            '<!-- ko if: status() === "switch" -->',
+                            button({
+                                class: 'btn btn-primary',
+                                dataBind: {
+                                    click: 'doSwitchToken'
+                                }
+                            }, 'Switch to this token'),
+                            '<!-- /ko -->',
+                            '<!-- ko if: status() === "use" -->',
+                            button({
+                                class: 'btn btn-primary',
+                                dataBind: {
+                                    click: 'doUseToken'
+                                }
+                            }, 'Login with this token'),
+                            '<!-- /ko -->',
+                            '<!-- ko if: status() === "loading" -->',
+                            html.loading(),
+                            '<!-- /ko -->'
+                        ])
+                    }),
+                    '<!-- ko if: token() -->',
+                    BS.buildPanel({
+                        title: 'Logout',
+                        body: div([
+                            p([
+                                'Logging out from the login widget does not work in the ',
+                                span({
+                                    dataBind: {
+                                        text: 'deployEnvironment'
+                                    }
+                                }),
+                                ' environment. You will need to use a special logout feature below.'
+                            ]),
+                            p(['Please use ', button({
+                                type: 'button',
+                                class: 'btn btn-danger',
+                                dataBind: {
+                                    click: 'doLogout'
+                                }
+                            }, 'This Logout Button')])
+                        ])
+                    }),
+                    '<!-- /ko -->'
+                ])
+            ])
+        ]);
+    }
+
+    function viewModel(params) {
+        var token = ko.observable(params.token);
+        var newToken = params.newToken;
+        var runtime = params.runtime;
+        var deployEnvironment = runtime.config('deploy.environment');
+
+        var canSend = false;
+        if (envs[deployEnvironment] && envs[deployEnvironment].targets) {
+            canSend = true;
+        }
+
+        var auth2 = runtime.service('session').getClient();
+
+        var status = ko.observable();
+
+        var message = ko.pureComputed(function () {
+            if (!newToken) {
+                status('no-msg');
+                return 'No msg param provided';
+            } else {
+                try {
+                    if (token() && token().length > 0) {
+                        if (token() === newToken.token) {
+                            status('same');
+                            return p([
+                                'The new token is the same as your current login token, there is nothing to do here, ',
+                                'you can go on about your business.'
+                            ]);
+                        } else {
+                            status('switch');
+                            return p([
+                                'The token you have selected for import from ',
+                                span({
+                                    style: {
+                                        fontWeight: 'bold'
+                                    }
+                                }, params.newToken.source),
+                                ' is different than the one set here in your ',
+                                span({
+                                    style: {
+                                        fontWeight: 'bold'
+                                    }
+                                }, runtime.config('deploy.environment')),
+                                ' session. ',
+                                ' You may switch tokens, which will sign out the current session token, and import ',
+                                'the one you have provided.'
+                            ]);
+                        }
+                    } else {
+                        status('use');
+                        return p([
+                            'There is no session token in the ',
+                            span({
+                                style: {
+                                    fontWeight: 'bold'
+                                }
+                            }, runtime.config('deploy.environment')),
+                            ' environment. ',
+                            'You may install one by importing the ',
+                            span({
+                                style: {
+                                    fontWeight: 'bold'
+                                }
+                            }, params.newToken.source),
+                            ' token that has been passed in.'
+                        ]);
+                    }
+                } catch (ex) {
+                    status('error');
+                    return 'Invalid msg param: ' + ex.message;
+                }
+            }
+        });
+
+        function switchToken() {
+            auth2.getTokenInfo()
+                .then(function (tokenInfo) {
+                    return auth2.auth2Client.revokeToken(auth2.getToken(), tokenInfo.id);
+                })
+                .then(function () {
+                    auth2.setSessionCookie(newToken.token, newToken.info.expires);
+                })
+                .catch(function (err) {
+                    console.error('ERROR', err);
+                });
+        }
+
+        function useToken() {
+            status('loading');
+            auth2.setSessionCookie(newToken.token, newToken.info.expires);
+        }
+
+        function doSwitchToken() {
+            status('loading');
+            switchToken();
+        }
+
+        function doUseToken() {
+            useToken(newToken);
+        }
+
+        function doLogout() {
+            runtime.service('session').logout();
+        }
+
+        runtime.recv('session', 'loggedin', function () {
+            token(runtime.service('session').getAuthToken());
+        });
+
+        return {
+            token: token,
+            source: params.source,
+            message: message,
+            newToken: newToken,
+            status: status,
+            deployEnvironment: deployEnvironment,
+            canSend: canSend,
+
+            doSwitchToken: doSwitchToken,
+            doUseToken: doUseToken,
+            doLogout: doLogout
+        };
+    }
+
+    function component() {
+        return {
+            template: template(),
+            viewModel: viewModel
+        };
+    }
+    ko.components.register('token-receiver', component());
+
+    function factory(config) {
+        var runtime = config.runtime,
+            container;
+
+        function attach(node) {
+            container = node;
+        }
+
+        function render(params) {
+            container.innerHTML = div([
+                div({
+                    dataBind: {
+                        component: {
+                            name: '"token-receiver"',
+                            params: {
+                                token: 'token',
+                                newToken: 'newToken',
+                                runtime: 'runtime'
+                            }
+                        }
+                    }
+                })
+            ]);
+            ko.applyBindings(params, container);
+        }
+
+        function renderUnsupported() {
+            container.innerHTML = BS.buildPanel({
+                type: 'danger',
+                title: 'Unsupported Deploy Environment',
+                body: div([
+                    p([
+                        'The ', runtime.config('deploy.environment'),
+                        ' deployment environment does not support token import'
+                    ])
+                ])
+            });
+        }
+
+        function start(params) {
+            // Is token import supported in this environment.
+            // TODO: make this a deploy config, but no time now.
+            var currentEnv = runtime.config('deploy.environment')
+            var envConfig = envs[currentEnv];
+            if (!envConfig) {
+                renderUnsupported();
+                return;
+            }
+            if (params.msg) {
+                // works by base64 ascii string -> raw bytes (string) -> non-ascii escaped -> utf8 string -> object
+                var msg = JSON.parse(decodeURIComponent(escape(window.atob(params.msg))));
+                var auth2Session = runtime.service('session').getClient();
+                auth2Session.getClient().getTokenInfo(msg.token)
+                    .then(function (tokenInfo) {
+                        var vm = {
+                            token: runtime.service('session').getAuthToken(),
+                            newToken: {
+                                token: msg.token,
+                                source: msg.source,
+                                info: tokenInfo
+                            },
+                            // tokenMsg: tokenMsg,
+                            runtime: runtime
+                        };
+                        render(vm);
+                    });
+            } else {
+                var vm = {
+                    token: runtime.service('session').getAuthToken(),
+                    newToken: null,
+                    runtime: runtime
+                };
+                render(vm);
+            }
+        }
+
+        function stop() {}
+
+        function detach() {}
+
+        return {
+            attach: attach,
+            start: start,
+            stop: stop,
+            detach: detach
+        };
+    }
+
+    return {
+        make: function (config) {
+            return factory(config);
+        }
+    };
+});

--- a/src/plugin/modules/dev/sendToken.js
+++ b/src/plugin/modules/dev/sendToken.js
@@ -1,0 +1,186 @@
+define([
+    'uuid',
+    'kb_common/html',
+    'kb_common/bootstrapUtils',
+    'kb_common/domEvent2'
+], function (
+    Uuid,
+    html,
+    BS,
+    DomEvent
+) {
+    'use strict';
+
+    var t = html.tag,
+        div = t('div'),
+        p = t('p'),
+        select = t('select'),
+        option = t('option'),
+        button = t('button'),
+        label = t('label');
+
+    var envs = {
+        ci: {
+            targets: {
+                cialt: {
+                    label: 'Alt CI',
+                    host: 'cialt.kbase.us'
+                },
+            }
+        },
+        cialt: {
+            targets: {
+                ci: {
+                    label: 'CI',
+                    host: 'ci.kbase.us'
+                }
+            }
+        },
+        prod: {
+            targets: {
+                appdev: {
+                    label: 'App Dev',
+                    host: 'appdev.kbase.us'
+                }
+            }
+        }
+    };
+
+
+    function factory(config) {
+        var runtime = config.runtime,
+            container;
+
+        var currentEnv = runtime.config('deploy.environment');
+        var targets;
+
+        function doSendEvent() {
+            // console.log('target', container);
+            var targetId = container.querySelector('[name="target"]').value;
+            var target = targets[targetId];
+            var token = runtime.service('session').getAuthToken();
+            var windowId = new Uuid(4).format();
+
+            var rawMessage = {
+                token: token,
+                source: runtime.config('deploy.environment')
+            };
+
+            // works by object -> utf8 -> encoded byte sequence -> raw bytes -> base64
+            var message = window.btoa(unescape(encodeURIComponent(JSON.stringify(rawMessage))));
+            var url = 'https://' + target.host + '#auth2/dev/receiveToken' + '?msg=' + message;
+            window.open(url, windowId);
+        }
+
+        function renderUnsupported() {
+            container.innerHTML = BS.buildPanel({
+                type: 'danger',
+                title: 'Unsupported Deploy Environment',
+                body: div([
+                    p([
+                        'The ', runtime.config('deploy.environment'),
+                        ' deployment environment does not support sending tokens.'
+                    ])
+                ])
+            });
+        }
+
+        function attach(node) {
+            container = node;
+        }
+
+        function start(params) {
+
+            var envConfig = envs[currentEnv];
+            if (!envConfig) {
+                renderUnsupported();
+                return;
+            }
+            targets = envs[currentEnv].targets;
+
+            // var supportedEnvs = ['prod'];
+            // if (supportedEnvs.indexOf(runtime.config('deploy.environment')) === -1) {
+            //     renderUnsupported();
+            //     return;
+            // }
+
+            var targetSelect = select({
+                name: 'target',
+                class: 'form-control'
+            }, Object.keys(targets).map(function (key) {
+                return option({
+                    value: key
+                }, targets[key].label + ' (' + targets[key].host + ')');
+            }));
+            var events = DomEvent.make({
+                node: container
+            });
+
+            container.innerHTML = div({
+                class: 'container-fluid',
+                style: {
+                    width: '100%'
+                }
+            }, [
+                div({ class: 'row' }, [
+                    div({ class: 'col-md-6' }, BS.buildPanel({
+                        title: 'Send Token',
+                        body: div({
+
+                        }, [
+                            // p(['Your current token: ', token]),
+                            div({
+                                class: 'form-group'
+                            }, [
+                                label('Select target environment: '),
+                                targetSelect,
+                            ]),
+                            div({
+                                class: 'form-group'
+                            }, [
+                                button({
+                                    type: 'button',
+                                    class: 'btn btn-primary',
+                                    id: events.addEvent({
+                                        type: 'click',
+                                        handler: doSendEvent
+                                    })
+                                }, 'Send Token')
+                            ])
+
+                            // p(['Link to set cookie in ', env, ', ', envHost, ':', link])
+                        ])
+                    })),
+                    div({ class: 'col-md-6' }, BS.buildPanel({
+                        title: 'Receive Token',
+                        body: div({}, [
+                            p(['After you send the token, the receiving app will use this panel.'])
+                        ])
+                    }))
+                ])
+            ]);
+            events.attachEvents();
+        }
+
+        function stop() {
+
+        }
+
+        function detach() {
+
+        }
+
+        return {
+            attach: attach,
+            start: start,
+            stop: stop,
+            detach: detach
+        };
+    }
+
+    return {
+        make: function (config) {
+            return factory(config);
+        }
+    };
+});

--- a/src/plugin/modules/lib/utils.js
+++ b/src/plugin/modules/lib/utils.js
@@ -44,8 +44,7 @@ define([
                         // entered with a valid token, redirect to the nextrequest,
                         // and if that is empty, the dashboard.
                         state: state,
-                        provider: providerId,
-                        stayLoggedIn: false
+                        provider: providerId
                     });
                 });
         }


### PR DESCRIPTION
- it works by packaging up a token in a url for the other web app host, and opening a window with this url.
- operates at auth2/dev/sendToken and auth2/dev/receiveToken
- first implementation, may change
