### PR TITLE
Add HDYHAU Question to Signup Form

### DIFF
--- a/src/plugin/iframe_root/modules/components/signupForm.js
+++ b/src/plugin/iframe_root/modules/components/signupForm.js
@@ -537,8 +537,8 @@ define([
                             surveydata: {
                                 referralSources: {
                                     question: referralSourceCopy,
-                                    response: referralSources.reduce((responses, source) => {
-                                        responses[source.id] = selectedReferralSources.indexOf(source.id) != -1;
+                                    response: referralSources().reduce((responses, source) => {
+                                        responses[source.id] = selectedReferralSources().indexOf(source.id) != -1;
                                         return responses;
                                     }, {}),
                                 },

--- a/src/plugin/iframe_root/modules/components/signupForm.js
+++ b/src/plugin/iframe_root/modules/components/signupForm.js
@@ -12,7 +12,8 @@ define([
     '../lib/dataSource',
     './policyResolver',
     './typeaheadInput',
-    './errorView'
+    './errorView',
+    'yaml!../../resources/data/referralSources.yaml',
 ], function (
     ko,
     reg,
@@ -27,7 +28,8 @@ define([
     DataSource,
     PolicyResolverComponent,
     TypeaheadInputComponent,
-    ErrorViewComponent
+    ErrorViewComponent,
+    referralSourceData
 ) {
     'use strict';
 
@@ -430,6 +432,11 @@ define([
             validationFieldBorder: true
         });
 
+        var referralSources = ko.observableArray(referralSourceData);
+        var selectedReferralSources = ko.observableArray().extend({
+          required: true
+        });;
+
         var allValid = ko.pureComputed(function () {
             var valid =
                 realname.isValid() &&
@@ -716,6 +723,8 @@ define([
             organization: organization,
             organizationDataSource: organizationDataSource,
             department: department,
+            referralSources: referralSources,
+            selectedReferralSources:selectedReferralSources,
             policiesToResolve: policiesToResolve,
             error: error,
 
@@ -1127,6 +1136,50 @@ define([
         };
     });
 
+    var buildReferralField = memoize(function () {
+        return {
+            field: div(
+                {
+                    class: 'form-group',
+                    style: {
+                        padding: '2px',
+                    },
+                    dataBind: {
+                        class: 'selectedReferralSources.validationFieldBorder'
+                    }
+                },
+                [
+                    label(['How did you hear about us? (select all that apply)', requiredIcon('selectedReferralSources')]),
+                    div({
+                        class: 'text-danger',
+                        style: {
+                            padding: '4px',
+                        },
+                        dataBind: {
+                            validationMessage: 'selectedReferralSources'
+                        }
+                    }),
+                    '<!-- ko foreach: referralSources -->',
+                    div({class:"checkbox"},
+                    [
+                        label([
+                            input({
+                                type: 'checkbox',
+                                dataBind: {
+                                    checkedValue: '$data.id',
+                                    checked: '$component.selectedReferralSources',
+                                },
+                            }),
+                            span({ dataBind: { text: '$data.name' } }),
+                        ])
+                    ]),
+                    '<!-- /ko -->'
+                ]
+            ),
+            info: '',
+        };
+    });
+
     function buildSignupForm() {
         return div(
             {
@@ -1269,6 +1322,25 @@ define([
                                                 class: 'col-md-5'
                                             },
                                             buildDepartmentField().field
+                                        ),
+                                        div({
+                                            class: 'col-md-7',
+                                            style: {
+                                                paddingTop: '20px'
+                                            }
+                                        })
+                                    ]
+                                ),
+                                div(
+                                    {
+                                        class: 'row'
+                                    },
+                                    [
+                                        div(
+                                            {
+                                                class: 'col-md-5'
+                                            },
+                                            buildReferralField().field
                                         ),
                                         div({
                                             class: 'col-md-7',

--- a/src/plugin/iframe_root/modules/components/signupForm.js
+++ b/src/plugin/iframe_root/modules/components/signupForm.js
@@ -433,9 +433,10 @@ define([
         });
 
         var referralSources = ko.observableArray(referralSourceData);
+        var referralSourceCopy = 'How did you hear about us? (select all that apply)';
         var selectedReferralSources = ko.observableArray().extend({
-          required: true
-        });;
+            required: true,
+        });
 
         var allValid = ko.pureComputed(function () {
             var valid =
@@ -531,9 +532,18 @@ define([
                             userdata: {
                             // title: role(),
                                 organization: organization(),
-                                department: department()
-                            }
-                        }
+                                department: department(),
+                            },
+                            surveydata: {
+                                referralSources: {
+                                    question: referralSourceCopy,
+                                    response: referralSources.reduce((responses, source) => {
+                                        responses[source.id] = selectedReferralSources.indexOf(source.id) != -1;
+                                        return responses;
+                                    }, {}),
+                                },
+                            },
+                        },
                     };
                     return userProfileClient
                         .set_user_profile({
@@ -724,6 +734,7 @@ define([
             organizationDataSource: organizationDataSource,
             department: department,
             referralSources: referralSources,
+            referralSourceCopy: referralSourceCopy,
             selectedReferralSources:selectedReferralSources,
             policiesToResolve: policiesToResolve,
             error: error,
@@ -1149,7 +1160,7 @@ define([
                     }
                 },
                 [
-                    label(['How did you hear about us? (select all that apply)', requiredIcon('selectedReferralSources')]),
+                    label([span({ dataBind: { text: 'referralSourceCopy' } }) , requiredIcon('selectedReferralSources')]),
                     div({
                         class: 'text-danger',
                         style: {

--- a/src/plugin/iframe_root/resources/data/referralSources.yaml
+++ b/src/plugin/iframe_root/resources/data/referralSources.yaml
@@ -1,0 +1,23 @@
+# Refferal Sources for HDYHAU Question
+---
+-
+  name: Journal Publication
+  id: journal-publication
+-
+  name: Workshop/Webinar
+  id: workshop-webinar
+-
+  name: Conference Presentation
+  id: conference-presentation
+-
+  name: Search Engine
+  id: search-engine
+-
+  name: Online Advertisement
+  id: online-ad
+-
+  name: Colleague
+  id: colleague
+-
+  name: Other
+  id: other


### PR DESCRIPTION
Adds a "How did you hear about us?" question to the signup page and stores the response in `profile.surveydata`.

Availible responses can be edited here: `src/plugin/iframe_root/resources/data/referralSources.yaml`

The copy of the the question, and both affirmative and negative responses are stored, such as to accommodate future changes to the signup question without changing the meaning of previously gathered responses (this may be overkill).

![Untitled](https://user-images.githubusercontent.com/5115845/94471752-8abbc280-017e-11eb-8b41-edb1fd87ca0d.png)
